### PR TITLE
add CI checking flake

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,39 @@
+name: check
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - "src/"
+      - "flake.lock"
+      - "flake.nix"
+      - ".sops.yml"
+      - ".github/workflows/build.yml"
+  pull_request:
+    paths:
+      - "src/"
+      - "flake.lock"
+      - "flake.nix"
+      - ".sops.yml"
+      - ".github/workflows/build.yml"
+
+jobs:
+  check:
+    strategy:
+      matrix:
+        # macos-14 is aarch64-darwin (silicone)
+        os: [ubuntu-latest, macos-14]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      # install nix
+      - uses: DeterminateSystems/nix-installer-action@main
+      # cache packages
+      - uses: DeterminateSystems/magic-nix-cache-action@main
+      # info on flake dependencies
+      - uses: DeterminateSystems/flake-checker-action@main
+        env:
+          FLAKE_CHECKER_NO_TELEMETRY: true
+        # validate all outputs
+      - name: Validate flake outputs
+        run: nix flake check

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,14 +3,14 @@ on:
   workflow_dispatch:
   push:
     paths:
-      - "src/"
+      - "src/**/*.nix"
       - "flake.lock"
       - "flake.nix"
       - ".sops.yml"
       - ".github/workflows/build.yml"
   pull_request:
     paths:
-      - "src/"
+      - "src/**/*.nix"
       - "flake.lock"
       - "flake.nix"
       - ".sops.yml"
@@ -19,6 +19,8 @@ on:
 jobs:
   check:
     strategy:
+      # always run all platforms disregarding failure
+      fail-fast: false
       matrix:
         # macos-14 is aarch64-darwin (silicone)
         os: [ubuntu-latest, macos-14]
@@ -36,4 +38,8 @@ jobs:
           FLAKE_CHECKER_NO_TELEMETRY: true
         # validate all outputs
       - name: Validate flake outputs
-        run: nix flake check
+        # Building uses too much storage (more than available on GitHub runners) and passing --not-build
+        # causes a lot of errors. So, for now comment out the home-manager derivations in the flake checks
+        # and only test system configs. Not sure what else can be done besides somehow fixing all the
+        # upstream errors caused by packages when passing --no-build.
+        run: nix flake check --show-trace

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,0 +1,28 @@
+name: update
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * 0" # Sunday at midnight
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # install nix
+      - uses: DeterminateSystems/nix-installer-action@main
+      # cache packages
+      - uses: DeterminateSystems/magic-nix-cache-action@main
+      # info on flake dependencies beforehand
+      - uses: DeterminateSystems/flake-checker-action@main
+        env:
+          FLAKE_CHECKER_NO_TELEMETRY: true
+        # TODO: run `nix flake check` on all platforms and if it works after update, submit PR
+        # update flake and send PR
+      - uses: DeterminateSystems/update-flake-lock@main
+        with:
+          pr-title: "Update flake.lock"
+          pr-labels: bot
+          # https://github.com/DeterminateSystems/update-flake-lock?tab=readme-ov-file#with-a-personal-authentication-token
+          token: ${{ secrets.GH_TOKEN_FOR_UPDATES }}

--- a/flake.nix
+++ b/flake.nix
@@ -70,5 +70,17 @@
         modules = [./home/nicky/mapro.nix];
       };
     };
+
+    # TODO: make function to auto create this
+    checks = {
+      aarch64-darwin = {
+        "mapro" = self.darwinConfigurations.mapro.system;
+
+        "nicky@mapro" = self.homeConfigurations."nicky@mapro".activationPackage;
+      };
+      x86_64-linux = {
+        "nicky@icarus" = self.homeConfigurations."nicky@icarus".activationPackage;
+      };
+    };
   };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -72,14 +72,17 @@
     };
 
     # TODO: make function to auto create this
+    # also, read github ci for why home manager configs are commented
     checks = {
       aarch64-darwin = {
         "mapro" = self.darwinConfigurations.mapro.system;
 
-        "nicky@mapro" = self.homeConfigurations."nicky@mapro".activationPackage;
+        # "nicky@mapro" = self.homeConfigurations."nicky@mapro".activationPackage;
       };
       x86_64-linux = {
-        "nicky@icarus" = self.homeConfigurations."nicky@icarus".activationPackage;
+        # nixos configs are checked by default
+
+        # "nicky@icarus" = self.homeConfigurations."nicky@icarus".activationPackage;
       };
     };
   };

--- a/home/nicky/icarus.nix
+++ b/home/nicky/icarus.nix
@@ -6,9 +6,9 @@
   imports = [
     ../shared/nix.nix
 
-    ../shared/desktop/wms/hyprland
-    # ../shared/desktop/wms/sway
-    ../shared/desktop/wayland.nix
+    ../shared/desktop/wms/hyprland.nix
+    # ../shared/desktop/wms/sway.nix
+    ../shared/desktop/wayland
 
     ../shared/desktop
     ../shared/desktop/discord.nix

--- a/home/shared/desktop/wms/gnome.nix
+++ b/home/shared/desktop/wms/gnome.nix
@@ -1,3 +1,2 @@
 {
-  imports = [./common];
 }

--- a/home/shared/desktop/wms/hyprland.nix
+++ b/home/shared/desktop/wms/hyprland.nix
@@ -6,11 +6,6 @@
 }: let
   grimblast = inputs.hyprland-contrib.packages.${pkgs.hostPlatform.system}.grimblast;
 in {
-  imports = [
-    ./common
-    ./common/wayland
-  ];
-
   home.packages = [
     grimblast
     pkgs.jaq

--- a/home/shared/desktop/wms/sway.nix
+++ b/home/shared/desktop/wms/sway.nix
@@ -3,11 +3,6 @@
   config,
   ...
 }: {
-  imports = [
-    ./common
-    ./common/wayland
-  ];
-
   wayland.windowManager = {
     sway = {
       enable = true;

--- a/home/shared/desktop/wms/wayfire.nix
+++ b/home/shared/desktop/wms/wayfire.nix
@@ -1,9 +1,4 @@
 {pkgs, ...}: {
-  imports = [
-    ./common
-    ./common/wayland
-  ];
-
   home.packages = with pkgs; [wayfire];
 
   xdg.configFile."wayfire.ini".text = ''

--- a/home/shared/dev/gpg.nix
+++ b/home/shared/dev/gpg.nix
@@ -5,7 +5,7 @@
 }: {
   services.gpg-agent = lib.mkIf pkgs.stdenv.isLinux {
     enable = true;
-    pinentryFlavor = "gnome3";
+    pinentryPackage = pkgs.pinentry-gnome3;
   };
 
   programs = {

--- a/hosts/nix-darwin/shared/homebrew.nix
+++ b/hosts/nix-darwin/shared/homebrew.nix
@@ -1,5 +1,5 @@
 {
-  environment.systemPath = [/opt/homebrew/bin];
+  # environment.systemPath = [/opt/homebrew/bin];
 
   homebrew = {
     enable = true;


### PR DESCRIPTION
Unfortunately, building the home manager config uses more storage than available on GitHub runners, and passing `--no-build` causes a lot of errors in packages, so for now the CI only tests nixos and nix-darwin configs.